### PR TITLE
Feature/full screen preview

### DIFF
--- a/browser-android/src/main/java/nolambda/uibook/browser/UIBookListActivity.kt
+++ b/browser-android/src/main/java/nolambda/uibook/browser/UIBookListActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.ui.platform.LocalContext
 import nolambda.uibook.browser.config.AppBrowserConfig
+import nolambda.uibook.components.bookform.GlobalState
 import nolambda.uibook.components.booklist.BookList
 import nolambda.uibook.factory.LibraryLoader
 
@@ -18,6 +19,10 @@ class UIBookListActivity : ComponentActivity() {
         setContent {
             val context = LocalContext.current
             BookList(bookNames = names) { index ->
+
+                // Disable the full screen mode first
+                GlobalState.fullScreenMode.setValue(false)
+
                 UIBookActivity.start(context, index)
             }
         }

--- a/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
+++ b/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
@@ -381,28 +381,21 @@ fun BookForm(
         setScale(scale * zoomChange)
     }
 
-    if (GlobalState.fullScreenMode.value) {
-        BookCanvas(
-            modifier = Modifier.fillMaxSize(),
-            selectedDevice = selectedDevice.value,
-            scale = scale,
-            transformableState = state,
-            bookView = bookView
-        )
-        return
-    }
-
     Column {
-        FormToolbar(
-            name = meta.name,
-            isMeasurementEnabled = isMeasurementEnabled.value,
-            selectedDevice = selectedDevice.value,
-            scale = scale,
-            onDeviceSelected = selectedDevice::value::set,
-            onToggleClick = { isMeasurementEnabled.value = isMeasurementEnabled.value.not() },
-            onScaleChange = setScale,
+        AnimatedVisibility(
+            visible = GlobalState.fullScreenMode.invertedValue,
             modifier = Modifier.zIndex(1F)
-        )
+        ) {
+            FormToolbar(
+                name = meta.name,
+                isMeasurementEnabled = isMeasurementEnabled.value,
+                selectedDevice = selectedDevice.value,
+                scale = scale,
+                onDeviceSelected = selectedDevice::value::set,
+                onToggleClick = { isMeasurementEnabled.value = isMeasurementEnabled.value.not() },
+                onScaleChange = setScale
+            )
+        }
 
         AdaptivePane(
             largeScreenThreshold = LARGE_SCREEN_THRESHOLD,
@@ -419,14 +412,18 @@ fun BookForm(
                 bookView = bookView
             )
 
-            ControlPane(
-                meta = meta,
-                inputData = inputData,
+            AnimatedVisibility(
+                visible = GlobalState.fullScreenMode.invertedValue,
                 modifier = adaptiveModifier.composed {
                     Modifier.background(MaterialTheme.colors.background)
                         .zIndex(1F)
                 }
-            )
+            ) {
+                ControlPane(
+                    meta = meta,
+                    inputData = inputData
+                )
+            }
         }
     }
 }

--- a/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
+++ b/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
@@ -139,20 +139,21 @@ private fun SourceCodeView(
                 .horizontalScroll(horizontalScrollState)
         )
 
-        Button(
+        OutlinedButton(
+            border = BorderStroke(1.dp, Color.Gray),
             onClick = {
                 AppBrowserConfig.clipboardManager.copyToClipboard(functionCode)
                 showClipboardState.value = true
             },
             modifier = Modifier
-                .align(Alignment.TopEnd)
+                .align(Alignment.BottomEnd)
                 .padding(16.dp)
                 .alpha(0.8f)
         ) {
             Icon(
                 imageVector = Icons.Default.ContentCopy,
                 contentDescription = "Copy to clipboard",
-                tint = Color.White
+                tint = Color.Gray
             )
         }
 

--- a/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
+++ b/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -356,8 +357,16 @@ private fun BookCanvas(
                 .alpha(0.8f)
         ) {
             Icon(
-                imageVector = Icons.Default.Fullscreen,
-                contentDescription = "Enter full screen mode",
+                imageVector = if (GlobalState.fullScreenMode.value) {
+                    Icons.Default.FullscreenExit
+                } else {
+                    Icons.Default.Fullscreen
+                },
+                contentDescription = if (GlobalState.fullScreenMode.value) {
+                    "Exit full screen mode"
+                } else {
+                    "Enter full screen mode"
+                },
                 tint = Color.Gray
             )
         }

--- a/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
+++ b/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/BookForm.kt
@@ -1,6 +1,7 @@
 package nolambda.uibook.components.bookform
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -21,17 +22,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +40,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -324,6 +326,47 @@ private fun AdaptivePane(
     }
 }
 
+/**
+ * Represent the canvas to draw the book preview
+ */
+@Composable
+private fun BookCanvas(
+    modifier: Modifier = Modifier,
+    selectedDevice: Device,
+    scale: Float,
+    transformableState: TransformableState,
+    bookView: ComposeEmitter,
+) {
+    Box(modifier = modifier) {
+        PixelGrid()
+        DeviceFrameWrapper(
+            selectedDevice = selectedDevice,
+            scale = scale,
+            transformableState = transformableState,
+            bookView
+        )
+
+        OutlinedButton(
+            onClick = GlobalState.fullScreenMode::toggle,
+            border = BorderStroke(1.dp, Color.Gray),
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+                .alpha(0.8f)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Fullscreen,
+                contentDescription = "Enter full screen mode",
+                tint = Color.Gray
+            )
+        }
+    }
+}
+
+/**
+ * BookForm is a combination of [BookCanvas] and [ControlPane] of UI Book
+ * As utility, it also contains a toolbar that contains needed actions for the book
+ */
 @Composable
 fun BookForm(
     meta: BookMetaData,
@@ -336,6 +379,17 @@ fun BookForm(
     val (scale, setScale) = remember { mutableStateOf(1f) }
     val state = rememberTransformableState { zoomChange, _, _ ->
         setScale(scale * zoomChange)
+    }
+
+    if (GlobalState.fullScreenMode.value) {
+        BookCanvas(
+            modifier = Modifier.fillMaxSize(),
+            selectedDevice = selectedDevice.value,
+            scale = scale,
+            transformableState = state,
+            bookView = bookView
+        )
+        return
     }
 
     Column {
@@ -357,19 +411,13 @@ fun BookForm(
             rowModifier = { Modifier.weight(1F) }
         ) { adaptiveModifier ->
 
-            Row(
-                modifier = Modifier.weight(1F).zIndex(0F)
-            ) {
-                Box {
-                    PixelGrid()
-                    DeviceFrameWrapper(
-                        selectedDevice = selectedDevice.value,
-                        scale = scale,
-                        transformableState = state,
-                        bookView
-                    )
-                }
-            }
+            BookCanvas(
+                modifier = adaptiveModifier.composed { zIndex(0F) },
+                selectedDevice = selectedDevice.value,
+                scale = scale,
+                transformableState = state,
+                bookView = bookView
+            )
 
             ControlPane(
                 meta = meta,

--- a/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/GlobalState.kt
+++ b/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/GlobalState.kt
@@ -1,7 +1,21 @@
 package nolambda.uibook.components.bookform
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 
 object GlobalState {
     val measurementEnabled = mutableStateOf(false)
+    val fullScreenMode = BooleanStateHolder(mutableStateOf(false))
+}
+
+
+class BooleanStateHolder(
+    private val state: MutableState<Boolean>,
+) {
+    fun toggle() {
+        state.value = !state.value
+    }
+
+    val value get() = state.value
 }

--- a/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/GlobalState.kt
+++ b/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/GlobalState.kt
@@ -18,4 +18,5 @@ class BooleanStateHolder(
     }
 
     val value get() = state.value
+    val invertedValue get() = !state.value
 }

--- a/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/GlobalState.kt
+++ b/browser-core/src/commonMain/kotlin/nolambda/uibook/components/bookform/GlobalState.kt
@@ -17,6 +17,10 @@ class BooleanStateHolder(
         state.value = !state.value
     }
 
+    fun setValue(value: Boolean) {
+        state.value = value
+    }
+
     val value get() = state.value
     val invertedValue get() = !state.value
 }

--- a/browser-desktop/src/jvmMain/kotlin/nolambda/uibook/browser/desktop/Main.kt
+++ b/browser-desktop/src/jvmMain/kotlin/nolambda/uibook/browser/desktop/Main.kt
@@ -1,9 +1,13 @@
 package nolambda.uibook.browser.desktop
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideIn
+import androidx.compose.animation.slideOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -11,11 +15,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.simulateHotReload
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
@@ -29,6 +32,7 @@ import nolambda.uibook.browser.config.BrowserConfig
 import nolambda.uibook.browser.config.ResourceLoader
 import nolambda.uibook.clipboard.ClipboardManager
 import nolambda.uibook.clipboard.DesktopClipboardManager
+import nolambda.uibook.components.bookform.GlobalState
 import nolambda.uibook.components.booklist.BookList
 import nolambda.uibook.factory.BookConfig
 import nolambda.uibook.factory.DesktopLibraryLoader
@@ -71,15 +75,23 @@ fun runBrowser() {
             MaterialTheme {
                 var selectedIndex by remember { mutableStateOf(-1) }
                 Row {
-                    ComponentList(
-                        names = names,
-                        modifier = Modifier.zIndex(2f)
-                    ) { index ->
-                        selectedIndex = index
+                    val isFullScreen = GlobalState.fullScreenMode.value
+                    AnimatedVisibility(
+                        modifier = Modifier.weight(1F).zIndex(2f),
+                        visible = isFullScreen.not(),
+                        exit = slideOut { fullSize -> IntOffset(-fullSize.width, 0) },
+                        enter = slideIn { fullSize -> IntOffset(-fullSize.width, 0) }
+                    ) {
+                        ComponentList(
+                            names = names,
+                        ) { index ->
+                            selectedIndex = index
+                        }
                     }
+
                     ComponentViewer(
-                        modifier = Modifier.zIndex(1f),
                         selectedIndex = selectedIndex,
+                        modifier = Modifier.weight(3F).zIndex(1f),
                         library = library
                     )
                 }
@@ -89,12 +101,12 @@ fun runBrowser() {
 }
 
 @Composable
-private fun RowScope.ComponentList(
+private fun ComponentList(
     names: List<String>,
     modifier: Modifier = Modifier,
     onSelected: (index: Int) -> Unit,
 ) {
-    Box(modifier = Modifier.weight(1F).composed { modifier }) {
+    Box(modifier = modifier) {
         BookList(
             bookNames = names,
             modifier = Modifier
@@ -106,7 +118,7 @@ private fun RowScope.ComponentList(
 }
 
 @Composable
-private fun RowScope.ComponentViewer(
+private fun ComponentViewer(
     selectedIndex: Int,
     modifier: Modifier = Modifier,
     library: UIBookLibrary,
@@ -116,7 +128,7 @@ private fun RowScope.ComponentViewer(
     }
 
     Box(
-        modifier = Modifier.weight(3F).composed { modifier }
+        modifier = modifier
     ) {
 
         val isSelected = selectedIndex >= 0


### PR DESCRIPTION
## Description

Add a full-screen preview toggle in the book canvas. This is useful when we want to preview the book on an actual device or just take a screenshot of the book itself.

## Preview - Desktop

https://user-images.githubusercontent.com/1691440/207996703-cd4b02ce-32b6-4551-b85a-b2df1e3ccfdb.mp4

## Preview - Android

https://user-images.githubusercontent.com/1691440/207996804-200833e8-d1b4-4131-a0ac-c9fe7ca39973.mp4


